### PR TITLE
Change Docker base image to python:3-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-alpine
+FROM python:3-alpine
 
 WORKDIR /app
 
@@ -21,8 +21,3 @@ EXPOSE 80
 CMD sh -c "python -u comaps.py && nginx -g 'daemon off;'"
 
 VOLUME ["/maps"]
-
-
-
-
-


### PR DESCRIPTION
Hi,
Python 3.13 is already not the latest version of Python 3.

I assume that all future versions of Python 3 will be able to run this script, so I suggest to not pin the minor version.